### PR TITLE
Bug fix (variable hoisting)

### DIFF
--- a/addon/models/radar.js
+++ b/addon/models/radar.js
@@ -226,11 +226,14 @@ export default class Radar {
   }
 
   filterMovement() {
+    let scrollY = 0;
+    let scrollX = 0;
+    
     // cache the scroll offset, and discard the cycle if
     // movement is within (x) threshold
     if(this.scrollContainer) {
-      const scrollY = this.scrollContainer.scrollTop;
-      const scrollX = this.scrollContainer.scrollLeft;
+      scrollY = this.scrollContainer.scrollTop;
+      scrollX = this.scrollContainer.scrollLeft;
     }
     const _scrollY = this.scrollY;
     const _scrollX = this.scrollX;


### PR DESCRIPTION
`const` and `let` are not hoisted to the top of the function (unlike `var`), and only live in the block they are declared in.
This caused `scrollY` and `scrollX` to be undefined outside of the `if` block